### PR TITLE
Add JSONfn as dependency and use it to parse chartjs options

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "prettier": "^2.3.0",
     "sort-package-json": "^1.50.0",
     "vuepress": "^1.8.2",
-    "vuepress-theme-gungnir": "^0.2.0",
-    "json-fn": "^1.1.1"
+    "vuepress-theme-gungnir": "^0.2.0"
   },
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "prettier": "^2.3.0",
     "sort-package-json": "^1.50.0",
     "vuepress": "^1.8.2",
-    "vuepress-theme-gungnir": "^0.2.0"
+    "vuepress-theme-gungnir": "^0.2.0",
+    "json-fn": "^1.1.1"
   },
   "useWorkspaces": true
 }

--- a/packages/plugins/chart/lib/Chart.vue
+++ b/packages/plugins/chart/lib/Chart.vue
@@ -6,6 +6,7 @@
 
 <script>
 import Chart from "chart.js";
+import JSONfn from "json-fn";
 
 export default {
   name: "Chart",
@@ -20,7 +21,7 @@ export default {
     }
   },
   mounted() {
-    const data = JSON.parse(this.code);
+    const data = JSONfn.parse(this.code);
     const ctx = this.$refs.chartjs.getContext("2d");
     new Chart(ctx, data);
   }

--- a/packages/theme-gungnir/package.json
+++ b/packages/theme-gungnir/package.json
@@ -34,6 +34,7 @@
     "@vssue/vuepress-plugin-vssue": "^1.4.8",
     "@vuepress/plugin-blog": "1.9.4",
     "@vuepress/plugin-google-analytics": "^1.8.2",
+    "json-fn": "^1.1.1",
     "markdown-it-chain": "^1.3.0",
     "md5": "2.3.0",
     "oh-vue-icons": "^0.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6162,6 +6162,11 @@ json-buffer@3.0.0:
   resolved "https://registry.npm.taobao.org/json-buffer/download/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-fn@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/json-fn/-/json-fn-1.1.1.tgz#4293c9198a482d6697d334a6e32cd0d221121e80"
+  integrity sha1-QpPJGYpILWaX0zSm4yzQ0iESHoA=
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npm.taobao.org/json-parse-better-errors/download/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
This enables functions to be passed as options to chartjs, e.g. for custom formatting of scale/axis tickmarks. The function must be passed in quotes:
{
"scales": {
  "yAxes":{
    "ticks": {
      "callback": "function(value){return value+'%' }"
    }
  }
}
...
}