### PR TITLE
fix(plugin-giscus): fix giscus lang options setting

### DIFF
--- a/packages/plugins/giscus/src/client/Giscus.ts
+++ b/packages/plugins/giscus/src/client/Giscus.ts
@@ -15,7 +15,9 @@ declare const __GISCUS_OPTIONS__: GiscusOptions;
 const options = __GISCUS_OPTIONS__;
 
 declare const __SITE_LOCALES__: any;
+declare const __SITE_LANG__: string;
 const siteLocales = __SITE_LOCALES__;
+const siteLang = __SITE_LANG__;
 
 const langMap = {
   "en-us": "en",
@@ -72,7 +74,7 @@ export default defineComponent({
     const resolvedLang = computed(() => {
       if (lang.value === "auto") {
         const locale = siteLocales[routeLocale.value];
-        const lang = locale && locale.lang;
+        const lang = (locale && locale.lang) || siteLang;
         if (lang && langMap[lang.toLowerCase()])
           return langMap[lang.toLowerCase()];
       }

--- a/packages/plugins/giscus/src/client/Giscus.ts
+++ b/packages/plugins/giscus/src/client/Giscus.ts
@@ -78,7 +78,7 @@ export default defineComponent({
         if (lang && langMap[lang.toLowerCase()])
           return langMap[lang.toLowerCase()];
       }
-      return "en";
+      return langMap[lang.value.toLowerCase()] ?? "en";
     });
 
     const getScriptElement = () => {

--- a/packages/plugins/giscus/src/node/index.ts
+++ b/packages/plugins/giscus/src/node/index.ts
@@ -10,7 +10,8 @@ const giscusPlugin: Plugin<GiscusOptions> = (options: GiscusOptions, app) => {
 
     define: {
       __GISCUS_OPTIONS__: options,
-      __SITE_LOCALES__: app.siteData.locales
+      __SITE_LOCALES__: app.siteData.locales,
+      __SITE_LANG__: app.siteData.lang
     },
 
     clientAppEnhanceFiles: path.resolve(


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

issue: #57 

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

- fix(plugin-giscus): fix giscus lang to support page lang
- fix(plugin-giscus): fix overwrite giscus lang options of theme config

## Description
1. The current language setting only supports the user to set the `locales` lang attribute. If the user does not set it, in the case of a single language, the lang attribute of the web page should be obtained and set.
2. Should support user overwrite configuration items

## Test Case

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test case.
![image](https://user-images.githubusercontent.com/40693636/163552825-82d02c5d-02af-47e5-a4f7-7730db566b83.png)

