### PR TITLE
fix: scrollbar styles in code blocks #77

### DIFF
--- a/packages/theme/src/client/styles/components/code.scss
+++ b/packages/theme/src/client/styles/components/code.scss
@@ -31,6 +31,19 @@ pre[class*="language-"] {
   padding: 1em;
   margin: 0.5em 0;
   overflow: auto;
+
+  &::-webkit-scrollbar {
+    height: 0.6rem;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--code-scroll-bar-color);
+    border-radius: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--c-brand);
+  }
 }
 
 :not(pre) > code[class*="language-"],

--- a/packages/theme/src/client/styles/mode/light.scss
+++ b/packages/theme/src/client/styles/mode/light.scss
@@ -1,4 +1,4 @@
-@import '../_variables';
+@import "../_variables";
 
 :root {
   // brand colors
@@ -44,6 +44,7 @@
   --code-bg-color: #282c34;
   --code-hl-bg-color: rgba(0, 0, 0, 0.66);
   --code-ln-color: #9e9e9e;
+  --code-scroll-bar-color: #64748b;
   --code-ln-wrapper-width: 3rem;
   --inline-code-color: #{$inlineCodeText};
   --inline-code-bg-color: #{$inlineCodeBg};
@@ -57,9 +58,9 @@
   --box-shadow-inset: #{$boxShadowInset};
 
   // font vars
-  --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  --font-family-code: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  --font-family-code: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
 
   // layout vars
   --navbar-height: 3.6rem;


### PR DESCRIPTION
## Related ISSUE

link #77

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [x] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

took a better look for scrollbar styles in code blocks.

## Description

As the issue described, the scrollbar styles in code blocks are abrupt, so I've changed the styles to let them look friendly.

## Before

![image](https://user-images.githubusercontent.com/42316353/177267775-1d584a7e-577a-48c2-ab8a-85207ec5317b.png)

![image](https://user-images.githubusercontent.com/42316353/177267705-95417847-569c-494e-b35d-13071b02d358.png)

## After

![test](https://user-images.githubusercontent.com/42316353/177266185-2b6e5fc8-2470-4791-b534-2b55eadae95a.gif)

In addition, I did not modify the quotation marks format, but by husky.